### PR TITLE
Bump through2 and tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "url": "https://github.com/brycebaril/through2-filter/issues"
   },
   "devDependencies": {
-    "tape": "^3.4.0",
+    "tape": "^4.0.0",
     "stream-spigot": "^3.0.5",
     "concat-stream": "^1.4.7"
   },
   "dependencies": {
-    "through2": "~0.6.3",
+    "through2": "~2.0.0",
     "xtend": "~4.0.0"
   }
 }


### PR DESCRIPTION
The latest stable [through2](https://github.com/rvagg/through2) uses Streams3 (similar to the latest node/io.js).
